### PR TITLE
[codex] resolve uuid advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: 11.1.1
+
 importers:
 
   .:
@@ -3154,9 +3157,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vite-plugin-pwa@1.3.0:
@@ -4238,7 +4240,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-simple-animate: 3.5.3(react-dom@19.2.7(react@19.2.7))
       use-deep-compare-effect: 1.8.1(react@19.2.7)
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -6608,7 +6610,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   vite-plugin-pwa@1.3.0(vite@7.3.6(jiti@1.21.7)(terser@5.48.0))(workbox-build@7.4.1(@types/babel__core@7.20.5))(workbox-window@7.4.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@
 packages:
   - .
 
+overrides:
+  uuid: 11.1.1
+
 allowBuilds:
   esbuild: true
   unrs-resolver: true

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npx --yes pnpm@11.9.0 install --frozen-lockfile"
+}


### PR DESCRIPTION
## Summary

- Force `uuid` to `11.1.1` through pnpm overrides
- Regenerate the lockfile so `@hookform/devtools` resolves to the patched `uuid` version
- Pin pnpm `11.9.0` and make Vercel preview installs use that version

## Root Cause

Dependabot alert #59 was caused by `@hookform/devtools@4.4.0` pulling `uuid@8.3.2`, which is vulnerable to GHSA-w5hq-g745-h8pq. The latest `@hookform/devtools` still declares the same `uuid` range, so an override is the smallest targeted fix.

Vercel also selected pnpm 9 for this project based on project creation date, which could not install the pnpm 11 lockfile with the new override metadata. The PR pins pnpm and uses a Vercel install command that runs `pnpm@11.9.0` directly.

## Validation

- `pnpm audit --prod=false`
- `pnpm why uuid`
- `pnpm lint`
- `pnpm build`
- Vercel preview deployment passed
- CodeQL passed